### PR TITLE
Bump NPM To 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "size-contracts": "hardhat size-contracts"
   },
   "devDependencies": {
-    "@f8n/fnd-protocol": "2.1.0-beta.1",
+    "@f8n/fnd-protocol": "2.1.0",
     "@manifoldxyz/royalty-registry-solidity": "1.0.9",
     "@nomiclabs/hardhat-ethers": "2.0.5",
     "@nomiclabs/hardhat-waffle": "2.0.3",


### PR DESCRIPTION
Dependent on release of https://github.com/f8n/fnd-protocol/pull/57.

- [ ] update yarn.lock